### PR TITLE
Do a little less deserialization on the passed strings

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -19,5 +19,5 @@ neon = "0.4.0"
 
 # Library specific crates
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = {version = "1.0", features = ["raw_value"] }
 voca_rs = "1.10.1"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -5,18 +5,20 @@
 use neon::prelude::*;
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Result, Value};
+use serde_json::{value::RawValue, Result, Value};
 use voca_rs::count;
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Delta {
-    ops: Vec<DeltaOps>
+pub struct Delta<'a> {
+    #[serde(borrow)]
+    ops: Vec<DeltaOps<'a>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DeltaOps {
-    attributes: Option<Value>,
-    insert: Value
+pub struct DeltaOps<'a> {
+    insert: String,
+    #[serde(borrow)]
+    attributes: Option<&'a RawValue>,
 }
 
 fn count_words(mut ctx: FunctionContext) -> JsResult<JsNumber> {
@@ -27,15 +29,13 @@ fn count_words(mut ctx: FunctionContext) -> JsResult<JsNumber> {
     }
 }
 
-fn try_count_words(text: &str) -> Result<u32> {
+pub fn try_count_words(text: &str) -> Result<u32> {
     let work_content: Delta = serde_json::from_str(text)?;
-    let all_text = work_content
-        .ops
-        .iter()
-        .filter(|x| x.insert.is_string())
-        .map(|x| x.insert.as_str().unwrap())
-        .collect::<String>();
-    let word_count = count::count_words(&all_text, "");
+    let mut string_builder = String::new();
+    for chunk in work_content.ops.iter().map(|x| &x.insert) {
+        string_builder.push_str(chunk);
+    }
+    let word_count = count::count_words(&string_builder, "");
     Ok(word_count as u32)
 }
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -29,7 +29,7 @@ fn count_words(mut ctx: FunctionContext) -> JsResult<JsNumber> {
     }
 }
 
-pub fn try_count_words(text: &str) -> Result<u32> {
+fn try_count_words(text: &str) -> Result<u32> {
     let work_content: Delta = serde_json::from_str(text)?;
     let mut string_builder = String::new();
     for chunk in work_content.ops.iter().map(|x| &x.insert) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "neon-cli": "^0.4.0"
   },
   "scripts": {
-    "install": "neon build"
+    "install": "neon build --release"
   },
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
This demonstrates improvements of around ~1ms in practice when called from the Javascript side. Also, I imagine it helps with memory, though I didn't benchmark that.

The big difference is that we no longer even try to deserialize `attributes` on the `insert` object--we just pass them right through. We also no longer do little incremental deserializations, because we no longer interpret each `insert` as its own little `serde_json::Value`--we just say it's a `String`, and it gets handled in the initial deserialization pass.